### PR TITLE
Make shumlib unit tests aware of OpenMP settings

### DIFF
--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Set up additional files for the UM:
-# 1) Check out/copy, build and install GCOM
-# 2) Check out/copy, build and install the necessary parts of shumlib
-# 3) Create keyword.cfg file containing mirror and offline keywords
-# 4) Add the kgo-database rose-ana setting to rose.conf
+# 1) Create keyword.cfg file containing mirror and offline keywords
+# 2) Add the kgo-database rose-ana setting to rose.conf
+# 3) Check out/copy, build and install GCOM
+# 4) Check out/copy, build and install shumlib
 # 5) Define $UMDIR
 
 function usage {

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -275,7 +275,7 @@ for shum_omp in true false; do
   # Test the library
   echo "Testing Shumlib $omp library..."
   echo "Test output at $install_dir/test.log"
-  make -f make/${vm_config}.mk test &> "$install_dir/test.log"
+  SHUM_OPENMP=$shum_omp make -f make/${vm_config}.mk test &> "$install_dir/test.log"
   if [ $? -ne 0 ]; then
     echo "Shumlib $omp tests failed."
     exit 1


### PR DESCRIPTION
As of r1096 of the shumlib trunk, the unit tests need to know whether OpenMP is enabled or not when testing the new thread_utils library. Note that the tests will not _report_ failure until r1118, when the unit tests begin returning non-zero exit codes. As of r1118 the um-setup script will detect the unit tests have failed and abort, preventing the shumlib no-OpenMP libraries from being installed.

The solution is to make the unit tests OpenMP-aware.

@dpmatthews @scwhitehouse please review.