### PR TITLE
Add support for building the UMDPs

### DIFF
--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -11,5 +11,8 @@ set -x
 #### Install UM and mule dependencies
 apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 libgrib-api-dev python-numpy python-dev python-mock
 
+#### Install UMDP dependencies
+apt-get install -y texlive texlive-latex-extra texlive-generic-extra texlive-science
+
 #### Add mule to the python packages
 echo "$HOME/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -8,11 +8,15 @@ fi
 
 set -x
 
-#### Install UM and mule dependencies
+echo "Installing UM and mule dependencies..."
 apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 libgrib-api-dev python-numpy python-dev python-mock
 
-#### Install UMDP dependencies
-apt-get install -y texlive texlive-latex-extra texlive-generic-extra texlive-science
-
-#### Add mule to the python packages
+echo
+echo "Adding mule to the installed python packages..."
 echo "$HOME/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth
+
+echo
+echo "Installing UMDP dependencies..."
+apt-get install -y texlive texlive-latex-extra texlive-generic-extra texlive-science
+echo
+echo "Finished."


### PR DESCRIPTION
In order to be able to build the Unified Model Documentation Papers on the VM some additional texlive packages are required. @scwhitehouse @dpmatthews please review.