### PR TITLE
Use Cylc 7.6 option to avoid returning control to the um-setup script early

### DIFF
--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -183,7 +183,7 @@ echo "Installing GCOM from: $gcom_src"
 cd $tmpdir/wc
 echo "Running rose stem to build GCOM..."
 
-rose stem --quiet --group=all --name=gcom_install --new -- --debug
+rose stem --quiet --group=all --name=gcom_install --new -- --no-detach
 if [ $? -ne 0 ]; then
   echo "Failed to launch GCOM rose stem suite."
   exit 1


### PR DESCRIPTION
The um-setup script uses the --debug option to cylc run, to prevent the rose stem suite that installs GCOM from returning control to the script until it has finished. At Cylc 7.6 this no longer works, control returns early and the script fails.

At Cylc 7.6 the correct option to avoid daemonisation is --no-detach (https://github.com/cylc/cylc/pull/2475).