### PR TITLE
UM installation fixes

### DIFF
--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -86,10 +86,10 @@ function process_args {
   fi
 }
 
-#if [[ $USER != root ]]; then
-#  echo "Please run this command via sudo"
-#  exit 1
-#fi
+if [[ $USER != root ]]; then
+  echo "Please run this command via sudo"
+  exit 1
+fi
 
 # Set defaults
 if [ $ubuntu_major -ge 18 ]; then

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -7,27 +7,28 @@ ubuntu_major=$(lsb_release -rs | cut -d. -f1)
 
 function usage {
   # Print command line options
-  echo
-  echo 'Usage: um-setup [-e|--eccodes] [-g|--grib-api] [-v|--version <x.y>]'
+  echo 'Usage: install-um-extras [-e|--eccodes] [-g|--grib-api] [-v|--version <x.y>]'
   echo 'Options:'
   echo '  -e, --eccodes        Install the EcCodes GRIB library'
   echo '  -g, --grib-api       Install the GRIB-API GRIB library'
   echo '  -h, --help           Show this help and exit'
   echo '  -v, --version <x.y>  Install packages for the selected UM version'
   echo
-  echo 'um-setup will install the packages necessary for using the UM and UMDPs.'
+  echo 'This script will install the packages necessary for using the UM and UMDPs.'
   echo "The packages required for the UM's GRIB functionality vary by UM version:"
-  echo ' - UM 11.2 or later requires the EcCodes library.'
   echo ' - UM 11.1 or earlier requires the GRIB-API library.'
-  echo 'Use the -v option to automatically install the correct packages, e.g.:'
-  echo '  um-setup -v 11.2'
-  echo 'Alternatively, the --eccodes or --grib-api arguments may be provided to'
-  echo 'explicitly choose one library over another.'
+  echo ' - UM 11.2 or later requires the EcCodes library.'
   echo 'These two libraries are mutually exclusive and cannot be installed together.'
   echo
+  echo 'Use the -v argument to automatically install the correct packages, e.g.:'
+  echo '  install-um-extras -v 11.2'
+  echo 'Alternatively, the --eccodes or --grib-api arguments may be provided to'
+  echo 'explicitly select a particular library.'
+  echo 'To install a different library re-run the script with the appropriate argument.'
+  echo
   echo 'EcCodes is only available when running Ubuntu 18.04 or later, where it is'
-  echo 'the default. Earlier versions will default to the GRIB-API library.'
-  echo 'Re-run this script with a different option to install the alternative library.'
+  echo 'the default choice if no arguments are provided. If an earlier version of'
+  echo 'Ubuntu is detected the GRIB-API library will be installed by default instead.'
 }
 
 function ereport {
@@ -85,10 +86,10 @@ function process_args {
   fi
 }
 
-if [[ $USER != root ]]; then
-  echo "Please run this command via sudo"
-  exit 1
-fi
+#if [[ $USER != root ]]; then
+#  echo "Please run this command via sudo"
+#  exit 1
+#fi
 
 # Set defaults
 if [ $ubuntu_major -ge 18 ]; then

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -184,9 +184,11 @@ echo "Installing GCOM from: $gcom_src"
 cd $tmpdir/wc
 echo "Running rose stem to build GCOM..."
 
-rose stem --quiet --group=all --name=gcom_install --new -- --no-detach
+rose stem --quiet --group=all --name=gcom_install --new --no-gcontrol -- --no-detach
 if [ $? -ne 0 ]; then
-  echo "Failed to launch GCOM rose stem suite."
+  echo "Problem running GCOM rose stem suite."
+  echo "Check suite logs and output at /home/vagrant/cylc-run/gcom_install"
+  echo "or try http://localhost/rose-bush/jobs/$USER/gcom_install."
   exit 1
 fi
 echo "GCOM suite output at http://localhost/rose-bush/jobs/$USER/gcom_install"

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -188,10 +188,10 @@ rose stem --quiet --group=all --name=gcom_install --new --no-gcontrol -- --no-de
 if [ $? -ne 0 ]; then
   echo "Problem running GCOM rose stem suite."
   echo "Check suite logs and output at /home/vagrant/cylc-run/gcom_install"
-  echo "or try http://localhost/rose-bush/jobs/$USER/gcom_install."
+  echo "or try http://localhost/rose-bush/taskjobs/$USER?&suite=gcom_install."
   exit 1
 fi
-echo "GCOM suite output at http://localhost/rose-bush/jobs/$USER/gcom_install"
+echo "Suite output at http://localhost/rose-bush/taskjobs/$USER?&suite=gcom_install"
 
 # copy dirs to right place (remember may have to overwrite...)
 gdir="$HOME/umdir/gcom"

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -187,7 +187,7 @@ echo "Running rose stem to build GCOM..."
 rose stem --quiet --group=all --name=gcom_install --new --no-gcontrol -- --no-detach
 if [ $? -ne 0 ]; then
   echo "Problem running GCOM rose stem suite."
-  echo "Check suite logs and output at /home/vagrant/cylc-run/gcom_install"
+  echo "Check suite logs and output at $HOME/cylc-run/gcom_install"
   echo "or try http://localhost/rose-bush/taskjobs/$USER?&suite=gcom_install."
   exit 1
 fi


### PR DESCRIPTION
Fixes for the UM installation scripts:
 - install-um-extras help text had the wrong script name
 - install-um-extras help text was unclear on what happens when no arguments are provided
 - um-setup fails with the latest Rose & Cylc releases due to the --no-detach option reporting an error when the cylc gui is launched. As this did not work properly anyway (the gui was spawned when the suite shut down) it is disabled.
 - um-setup now reports where to look in the event that the GCOM rose stem suite fails (to compensate for the gui's removal).
@dpmatthews @scwhitehouse please could you take a look?