### PR TITLE
Add zenity to extra UM packages

### DIFF
--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -113,7 +113,7 @@ fi
 set -x
 
 echo "Installing UM and mule dependencies..."
-apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock $grib_library
+apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity $grib_library
 
 echo
 echo "Adding mule to the installed python packages..."


### PR DESCRIPTION
The UM's create_branch script has been updated to work with Zenity in order to produce a GUI (UM #4742), as an alternative to Kdialog. As this is supported on the current Ubuntu distributions (I believe it's one of the normally-installed packages, but has been removed from the stripped-down VMs) and only requires a couple of MB of space, it would be a nice addition to have. While the create_branch script is an optional extra, and currently works on the VM in text-only form, the VM is often used for training new students to use the UM and if we have a friendlier user interface available we should make use of it.

@scwhitehouse, @dpmatthews please review.