### PR TITLE
Fix auto discovery of most recent cylc version

### DIFF
--- a/usr/local/bin/install-rose-cylc-fcm
+++ b/usr/local/bin/install-rose-cylc-fcm
@@ -24,11 +24,11 @@ while [[ $# != 0 ]]; do
 done
 
 # Define software versions (use latest releases if not defined)
-FCM_VERSION=${FCM_VERSION:-$(curl -s https://api.github.com/repos/metomi/fcm/releases|\
+FCM_VERSION=${FCM_VERSION:-$(curl -s -L https://api.github.com/repos/metomi/fcm/releases|\
   grep tag_name|sort|tail -1|sed -e 's/^.*: "//' -e 's/".*$//')}
-CYLC_VERSION=${CYLC_VERSION:-$(curl -s https://api.github.com/repos/cylc/cylc/releases|\
+CYLC_VERSION=${CYLC_VERSION:-$(curl -s -L https://api.github.com/repos/cylc/cylc/releases|\
   grep tag_name|sort|tail -1|sed -e 's/^.*: "//' -e 's/".*$//')}
-ROSE_VERSION=${ROSE_VERSION:-$(curl -s https://api.github.com/repos/metomi/rose/releases|\
+ROSE_VERSION=${ROSE_VERSION:-$(curl -s -L https://api.github.com/repos/metomi/rose/releases|\
   grep tag_name|sort|tail -1|sed -e 's/^.*: "//' -e 's/".*$//')}
 
 #### Install FCM


### PR DESCRIPTION
The github api used to find the most recent tagged version of `cylc` is
currently responding with a 301 Moved Permanently response causing
`$CYLC_VERSION` to be empty and the installation of rose and cylc to
abort.

```
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/1836229/releases",
  "documentation_url": "https://developer.github.com/v3/#http-redirects"
}
```

This commit adds `-L` to the curl commands to ensure that redirects are
followed that the necessary response is given.