### PR TITLE
Enable VMware products to be used instead of VirtualBox for the Met Office Virtual Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You may have issues if both VMware and VirtualBox are installed, or if the Hyper
 ```
 config.vm.box = "uwbbi/bionic-arm64"
 ```
-in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file as you cannot use an amd64-based installation on an Apple Silicon (ARM-based) hardware.
+in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file as you cannot use an amd64-based installation on Apple Silicon (ARM-based) hardware.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -114,17 +114,25 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 ## VMware
 
-As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) can be used as an alternative to host the virtual machine. This is free for non-commercial use, and works on Windows and Linux systems ([VMware Fusion](https://www.vmware.com/uk/products/fusion.html) is a similar product for macOS). As a minimum you will need to download and install
+As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (Windows, Linux) or ([VMware Fusion](https://www.vmware.com/uk/products/fusion.html) (macOS) can be used as an alternative to host the virtual machine. VMware Workstation Player is free for non-commercial use. As a minimum you will need to download and install
 
-* [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html)
+* [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) **or** [VMware Fusion](https://www.vmware.com/uk/products/fusion.html)
 * The [Vagrant VMware utility](https://www.vagrantup.com/vmware/downloads)
 * The Vagrant VMware plugin by running the command `vagrant plugin install vagrant-vmware-desktop`
 
-The configuration settings can be found in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file. To bring the box up using VMware, run the command
+The configuration settings can be found in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file. To bring the box up using VMware, edit the [Vagrantfile](Vagrantfile) to point to the VMware configuration
+```
+load 'Vagrantfile.vmware_ubuntu-1804'
+```
+and run the command
 ```
 vagrant up --provider=vmware_desktop
 ```
-You may have issues with both VMware and VirtualBox installed, or if the Hyper-V hypervisor is also running.
+You may have issues with both VMware and VirtualBox installed, or if the Hyper-V hypervisor is also running. If you are using an Apple Silicon device with VMware Fusion you will need to set the following
+```
+config.vm.box = "uwbbi/bionic-arm64"
+```
+in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file as you cannot use an amd64-based installation on an Apple M1 (ARM-based) chip.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Table of contents:
 
 In order to use a virtual machine (VM), you must first install:
  * [VirtualBox](https://www.virtualbox.org/), software that enables running of virtual machines (version 5.1.x or later required).
-   * As an alternative, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) can also be used to run the virtual machine. See the [VMware section](#vmware) for further information.
+   * As an alternative, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) or [VMware Fusion](https://www.vmware.com/uk/products/fusion.html) can also be used to run the virtual machine. See the [VMware section](#vmware) for further information.
  * [Vagrant](https://www.vagrantup.com/), software that allows easy configuration of virtual machines (version 2.0.x or later required).
 
 These applications provide point-and-click installers for Windows and can usually be installed via the package manager on Linux systems.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 ## VMware
 
-As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (Windows, Linux) or ([VMware Fusion](https://www.vmware.com/uk/products/fusion.html) (macOS) can be used as an alternative to host the virtual machine. VMware Workstation Player is free for non-commercial use. As a minimum you will need to download and install
+As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (Windows, Linux) or ([VMware Fusion](https://www.vmware.com/uk/products/fusion.html) (macOS) can be used to host the virtual machine. VMware Workstation Player is free for non-commercial use.
+
+You will need to download and install
 
 * [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) **or** [VMware Fusion](https://www.vmware.com/uk/products/fusion.html)
 * The [Vagrant VMware utility](https://www.vagrantup.com/vmware/downloads)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ and run the command
 ```
 vagrant up --provider=vmware_desktop
 ```
-You may have issues with both VMware and VirtualBox installed, or if the Hyper-V hypervisor is also running. If you are using an Apple Silicon device with VMware Fusion you will need to set the following
+You may have issues if both VMware and VirtualBox are installed, or if the Hyper-V hypervisor is also running. If you are using an Apple Silicon device with VMware Fusion you will need to set the following
 ```
 config.vm.box = "uwbbi/bionic-arm64"
 ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 ## VMware
 
-As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) can be used as an alternative to host the virtual machine. This is free for non-commercial use, and works on Windows and Linux systems. You will need to download and install
+As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) can be used as an alternative to host the virtual machine. This is free for non-commercial use, and works on Windows and Linux systems ([VMware Fusion](https://www.vmware.com/uk/products/fusion.html) is a similar product for macOS). As a minimum you will need to download and install
 
 * [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html)
 * The [Vagrant VMware utility](https://www.vagrantup.com/vmware/downloads)
@@ -124,6 +124,7 @@ The configuration settings can be found in the [Vagrantfile.vmware_ubuntu-1804](
 ```
 vagrant up --provider=vmware_desktop
 ```
+You may have issues with both VMware and VirtualBox installed, or if the Hyper-V hypervisor is also running.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Table of contents:
 * [Optional Windows Software](#optional-windows-software)
   * [Git BASH](#git-bash)
   * [Cygwin](#cygwin)
+* [VMware](#vmware)
 * [Troubleshooting](#troubleshooting)
 * [Amazon AWS](#amazon-aws)
 
@@ -20,6 +21,7 @@ Table of contents:
 
 In order to use a virtual machine (VM), you must first install:
  * [VirtualBox](https://www.virtualbox.org/), software that enables running of virtual machines (version 5.1.x or later required).
+   * As an alternative, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) can also be used to run the virtual machine. See the [VMware section](#vmware) for further information.
  * [Vagrant](https://www.vagrantup.com/), software that allows easy configuration of virtual machines (version 2.0.x or later required).
 
 These applications provide point-and-click installers for Windows and can usually be installed via the package manager on Linux systems.
@@ -109,6 +111,19 @@ Then, instead of using a normal command window for launching the VM, you should 
 In Cygwin-X terminals, you can use many common Unix commands (e.g. cd, ls).
 Firstly run the command  `cd /cygdrive` followed by `ls` and you should see your Windows drives.
 Then use the `cd` command to navigate to the directory where you have extracted the setup files (e.g. `c/Users/User/metomi-vms-master`).
+
+## VMware
+
+As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) can be used as an alternative to host the virtual machine. This is free for non-commercial use, and works on Windows and Linux systems. You will need to download and install
+
+* [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html)
+* The [Vagrant VMware utility](https://www.vagrantup.com/vmware/downloads)
+* The Vagrant VMware plugin by running the command `vagrant plugin install vagrant-vmware-desktop`
+
+The configuration settings can be found in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file. To bring the box up using VMware, run the command
+```
+vagrant up --provider=vmware_desktop
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You may have issues if both VMware and VirtualBox are installed, or if the Hyper
 ```
 config.vm.box = "uwbbi/bionic-arm64"
 ```
-in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file as you cannot use an amd64-based installation on an Apple M1 (ARM-based) chip.
+in the [Vagrantfile.vmware_ubuntu-1804](Vagrantfile.vmware_ubuntu-1804) file as you cannot use an amd64-based installation on an Apple Silicon (ARM-based) hardware.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Table of contents:
 
 In order to use a virtual machine (VM), you must first install:
  * [VirtualBox](https://www.virtualbox.org/), software that enables running of virtual machines (version 5.1.x or later required).
-   * As an alternative, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) or [VMware Fusion](https://www.vmware.com/uk/products/fusion.html) can also be used to run the virtual machine. See the [VMware section](#vmware) for further information.
+   * As an alternative, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (version 16 or later) or [VMware Fusion Player](https://www.vmware.com/uk/products/fusion.html) (version 12 or later) can also be used to run the virtual machine. See the [VMware section](#vmware) for further information.
  * [Vagrant](https://www.vagrantup.com/), software that allows easy configuration of virtual machines (version 2.0.x or later required).
 
 These applications provide point-and-click installers for Windows and can usually be installed via the package manager on Linux systems.
@@ -114,11 +114,11 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 ## VMware
 
-As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (Windows, Linux) or ([VMware Fusion](https://www.vmware.com/uk/products/fusion.html) (macOS) can be used to host the virtual machine. VMware Workstation Player is free for non-commercial use.
+As an alternative to VirtualBox, [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (Windows, Linux) or ([VMware Fusion Player](https://www.vmware.com/uk/products/fusion.html) (macOS) can be used to host the virtual machine. VMware Workstation Player is free for non-commercial use and VMware Fusion Player is free with a Personal Use License.
 
 You will need to download and install
 
-* [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) **or** [VMware Fusion](https://www.vmware.com/uk/products/fusion.html)
+* [VMware Workstation Player](https://www.vmware.com/uk/products/workstation-player.html) (version 16 or later) **or** [VMware Fusion Player](https://www.vmware.com/uk/products/fusion.html) (version 12 or later)
 * The [Vagrant VMware utility](https://www.vagrantup.com/vmware/downloads)
 * The Vagrant VMware plugin by running the command `vagrant plugin install vagrant-vmware-desktop`
 

--- a/Vagrantfile.vmware_ubuntu-1804
+++ b/Vagrantfile.vmware_ubuntu-1804
@@ -5,13 +5,16 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "metomi-vm-ubuntu-1804"
+  # amd64-based system for VMware Workstation Player on Windows & Linux
   config.vm.box = "bento/ubuntu-18.04"
+  # use uwbbi/bionic-arm64 as the box if using VMware Fusion on macOS using Apple Silicon (ARM-based)
+  #config.vm.box = "uwbbi/bionic-arm64"
   # Remove "desktop" from the args below if only accessing via SSH
   # Remove "mosrs" from the args below if not accessing the Met Office Science Repository Service
   config.vm.provision :shell, path: "install.sh", args: "ubuntu 1804 desktop mosrs"
   config.ssh.forward_x11 = true
 
-  config.vm.provider :vmware_desktop do |vmware_desktop, override|
+  config.vm.provider "vmware_desktop" do |v|
     # Comment out the line below if only accessing via SSH
     v.gui = true
     # Modify the line below if you need more than 1GB RAM

--- a/Vagrantfile.vmware_ubuntu-1804
+++ b/Vagrantfile.vmware_ubuntu-1804
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.define "metomi-vm-ubuntu-1804"
+  config.vm.box = "bento/ubuntu-18.04"
+  # Remove "desktop" from the args below if only accessing via SSH
+  # Remove "mosrs" from the args below if not accessing the Met Office Science Repository Service
+  config.vm.provision :shell, path: "install.sh", args: "ubuntu 1804 desktop mosrs"
+  config.ssh.forward_x11 = true
+
+  config.vm.provider :vmware_desktop do |vmware_desktop, override|
+    # Comment out the line below if only accessing via SSH
+    v.gui = true
+    # Modify the line below if you need more than 1GB RAM
+    v.memory = 1024
+    v.cpus = 2
+  end
+
+end


### PR DESCRIPTION
Not all organisations allow the use of VirtualBox due to security concerns, and VMware is an alternative solution that does not involve the pay-as-you-use model of AWS. 

This has been tested on Windows Server 2022 using VMware Workstation Player 16.2.3 doing a full UMvn12.2 install and KGO check. It has also been tested on macOS 11.6.5 using the [VMware Fusion Tech Preview](https://blogs.vmware.com/teamfusion/2021/09/fusion-for-m1-public-tech-preview-now-available.html) to allow it to run on my Apple Silicon hardware (here the UM was not tested due to the hardware limitations, but Rosie and FCM were checked).