### PR TITLE
Update install-um-extras for newer UM scripts

### DIFF
--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -113,7 +113,7 @@ fi
 set -x
 
 echo "Installing UM and mule dependencies..."
-apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity libio-string-perl $grib_library
+apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity libio-stringy-perl libipc-run-perl libperl-critic-perl $grib_library
 
 echo
 echo "Adding mule to the installed python packages..."

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -113,7 +113,7 @@ fi
 set -x
 
 echo "Installing UM and mule dependencies..."
-apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity $grib_library
+apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity libio-string-perl $grib_library
 
 echo
 echo "Adding mule to the installed python packages..."


### PR DESCRIPTION
The additional scripts run by the UM rose stem make use of more Perl modules in newer UM versions. This requires the `install-um-extras` script to be updated to install the additional packages required to make these Perl modules available.