### PR TITLE
Updates for running the UM on Ubuntu 22.04 and additional help text and minor fix for using Ubuntu Pro with Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Table of contents:
 * [Optional Windows Software](#optional-windows-software)
   * [Git BASH](#git-bash)
   * [Cygwin](#cygwin)
+* [Ubuntu Pro](#ubuntu-pro)
 * [VMware](#vmware)
 * [libvirt](#libvirt)
 * [Troubleshooting](#troubleshooting)
@@ -112,6 +113,23 @@ Then, instead of using a normal command window for launching the VM, you should 
 In Cygwin-X terminals, you can use many common Unix commands (e.g. cd, ls).
 Firstly run the command  `cd /cygdrive` followed by `ls` and you should see your Windows drives.
 Then use the `cd` command to navigate to the directory where you have extracted the setup files (e.g. `c/Users/User/metomi-vms-master`).
+
+## Ubuntu Pro
+
+While Ubuntu 18.04 LTS went end-of-life in May 2023, an [Ubuntu Pro](https://ubuntu.com/pro) subscription can be used to get security updates for a further 5 years. This is free for personal use for up to 5 machines.
+
+However, care needs to be taken when following the [Tutorial](https://ubuntu.com/pro/tutorial). Before running the `sudo apt update && sudo apt upgrade` commands, you should first
+```
+sudo apt-mark hold gpg-agent
+```
+When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#guestadd-install), which can be done via the command-line by
+```
+sudo apt install virtualbox-guest-additions-iso
+sudo mount -o loop /usr/share/virtualbox/VBoxGuestAdditions.iso /media/cdrom
+sudo /media/cdrom/VBoxLinuxAdditions.run
+sudo umount /media/cdrom
+```
+and then rebooting the VM.
 
 ## VMware
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,12 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 ## Ubuntu Pro
 
-While Ubuntu 18.04 LTS went end-of-life in May 2023, an [Ubuntu Pro](https://ubuntu.com/pro) subscription can be used to get security updates for a further 5 years. This is free for personal use for up to 5 machines.
+While Ubuntu 18.04 LTS went end-of-life in May 2023, an [Ubuntu Pro](https://ubuntu.com/pro) subscription can be used to get security updates for a further 5 years. This is free for personal use for up to 5 machines and the process is documented in a [Tutorial](https://ubuntu.com/pro/tutorial). Before you run the `sudo apt update && sudo apt upgrade` commands, you should first
+```
+sudo apt-mark hold gpg-agent
+```
 
-However, care needs to be taken when following the [Tutorial](https://ubuntu.com/pro/tutorial). If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, in a similar way to how it is originally installed in the [install-mosrs](install-mosrs.sh) script:
+After rebooting, you may get the error "gpg-preset-passphrase: caching passphrase failed: Not supported". Here you will need to re-install gpg-agent manually, in a similar way to how it is originally installed in the [install-mosrs](install-mosrs.sh) script:
 ```
 sudo apt-get remove -q -y --auto-remove --purge gpg-agent
 curl -L -s -S https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.31.tar.bz2 | tar -xj
@@ -128,9 +131,12 @@ make
 sudo make install
 ```
 
-When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#additions-linux), which can be done via the command-line by
+When you reboot your VM you may also get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#additions-linux), which can be done via the command-line by
 ```
 sudo apt install -y virtualbox-guest-additions-iso
+```
+You may find that this is sufficient to fix the error after rebooting. If it is not, you can manually install them by
+```
 sudo mount -o loop /usr/share/virtualbox/VBoxGuestAdditions.iso /media/cdrom
 sudo /media/cdrom/VBoxLinuxAdditions.run
 sudo umount /media/cdrom

--- a/README.md
+++ b/README.md
@@ -118,16 +118,16 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 While Ubuntu 18.04 LTS went end-of-life in May 2023, an [Ubuntu Pro](https://ubuntu.com/pro) subscription can be used to get security updates for a further 5 years. This is free for personal use for up to 5 machines.
 
-However, care needs to be taken when following the [Tutorial](https://ubuntu.com/pro/tutorial). Before running the `sudo apt update && sudo apt upgrade` commands, you should first
+However, care needs to be taken when following the [Tutorial](https://ubuntu.com/pro/tutorial). Before running the `sudo apt update && sudo apt upgrade` commands, you should first try
 ```
 sudo apt-mark hold gpg-agent
 ```
-If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, as is done in the [install-mosrs](install-mosrs.sh) script:
+If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, in a similar way to how it is originally installed in the [install-mosrs](install-mosrs.sh) script:
 ```
 sudo apt-get remove -q -y --auto-remove --purge gpg-agent
 curl -L -s -S https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.31.tar.bz2 | tar -xj
 cd gnupg-2.0.31/
-./configure
+./configure CFLAGS="-fcommon"
 make
 sudo make install
 ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,15 @@ However, care needs to be taken when following the [Tutorial](https://ubuntu.com
 ```
 sudo apt-mark hold gpg-agent
 ```
-If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, as is done in the [install-mosrs](install-mosrs.sh) script.
+If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, as is done in the [install-mosrs](install-mosrs.sh) script:
+```
+sudo apt-get remove -q -y --auto-remove --purge gpg-agent
+curl -L -s -S https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.31.tar.bz2 | tar -xj
+cd gnupg-2.0.31/
+./configure
+make
+sudo make install
+```
 
 When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#additions-linux), which can be done via the command-line by
 ```

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ However, care needs to be taken when following the [Tutorial](https://ubuntu.com
 ```
 sudo apt-mark hold gpg-agent
 ```
+If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, as is done in the [install-mosrs](install-mosrs.sh) script.
+
 When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#additions-linux), which can be done via the command-line by
 ```
 sudo apt install virtualbox-guest-additions-iso

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ However, care needs to be taken when following the [Tutorial](https://ubuntu.com
 ```
 sudo apt-mark hold gpg-agent
 ```
-When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#guestadd-install), which can be done via the command-line by
+When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#additions-linux), which can be done via the command-line by
 ```
 sudo apt install virtualbox-guest-additions-iso
 sudo mount -o loop /usr/share/virtualbox/VBoxGuestAdditions.iso /media/cdrom

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sudo make install
 
 When you reboot your VM you may get the error "Vagrant was unable to mount VirtualBox shared folders". This can be fixed by [re-installing the VirtualBox guest additions](https://www.virtualbox.org/manual/ch04.html#additions-linux), which can be done via the command-line by
 ```
-sudo apt install virtualbox-guest-additions-iso
+sudo apt install -y virtualbox-guest-additions-iso
 sudo mount -o loop /usr/share/virtualbox/VBoxGuestAdditions.iso /media/cdrom
 sudo /media/cdrom/VBoxLinuxAdditions.run
 sudo umount /media/cdrom

--- a/README.md
+++ b/README.md
@@ -118,11 +118,7 @@ Then use the `cd` command to navigate to the directory where you have extracted 
 
 While Ubuntu 18.04 LTS went end-of-life in May 2023, an [Ubuntu Pro](https://ubuntu.com/pro) subscription can be used to get security updates for a further 5 years. This is free for personal use for up to 5 machines.
 
-However, care needs to be taken when following the [Tutorial](https://ubuntu.com/pro/tutorial). Before running the `sudo apt update && sudo apt upgrade` commands, you should first try
-```
-sudo apt-mark hold gpg-agent
-```
-If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, in a similar way to how it is originally installed in the [install-mosrs](install-mosrs.sh) script:
+However, care needs to be taken when following the [Tutorial](https://ubuntu.com/pro/tutorial). If you get the error `gpg-preset-passphrase: caching passphrase failed: Not supported` you will need to re-install gpg-agent manually, in a similar way to how it is originally installed in the [install-mosrs](install-mosrs.sh) script:
 ```
 sudo apt-get remove -q -y --auto-remove --purge gpg-agent
 curl -L -s -S https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.31.tar.bz2 | tar -xj

--- a/install-mosrs.sh
+++ b/install-mosrs.sh
@@ -19,10 +19,10 @@ if [[ $dist == ubuntu || ($dist == redhat && $release != centos7) ]]; then
   fi
   curl -L -s -S https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.31.tar.bz2 | tar -xj || error
   cd gnupg-2.0.31
-  if [[ $release != 2204 ]]; then
-    ./configure || error
-  else
+  if [[ ($dist == ubuntu && $release != 1604) ]]; then
     ./configure CFLAGS="-fcommon" || error
+  else
+    ./configure || error
   fi
   make || error
   make install || error

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -156,10 +156,14 @@ elif [ $ubuntu_major -eq 22 ]; then
     curl -L -s -S https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.30.2-Source.tar.gz | tar -xz
     cd eccodes-2.30.2-Source
     mkdir -p build && cd build
-    cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_JPG=ON ../.
+    mkdir -p /usr/src/eccodes
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/src/eccodes -DENABLE_JPG=ON ../.
     make
     ctest
     make install
+    cp /usr/src/eccodes/bin/* /usr/bin/.
+    cp /usr/src/eccodes/lib/*.so /usr/lib/.
+    cp /usr/src/eccodes/include/* /usr/include/.
     cd /home/${SUDO_USER}
     rm -rf eccodes-2.30.2-Source
 

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -134,7 +134,7 @@ elif [ $ubuntu_major -eq 22 ]; then
     # Settings for Ubuntu 22.04
 
     echo "Installing UM and mule dependencies..."
-    apt-get install -y libnetcdf-dev libhdf5-dev netcdf-bin libnetcdff-dev libnetcdff7
+    apt-get install -y libnetcdf-dev libhdf5-dev netcdf-bin libnetcdff-dev libnetcdff7 libio-stringy-perl libipc-run-perl libperl-critic-perl
 
     echo
     echo "Configuring UM python settings..."

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -18,8 +18,10 @@ function usage {
   echo "The packages required for the UM's GRIB functionality vary by UM version:"
   echo ' - UM 11.1 or earlier requires the GRIB-API library.'
   echo ' - UM 11.2 or later requires the EcCodes library.'
-  echo ' - UM 13.3 or later requires the use of Ubuntu 22.04 and installs eCcodes from source.'
   echo 'These two libraries are mutually exclusive and cannot be installed together.'
+  echo
+  echo 'UM 13.3 or later requires the use of Ubuntu 22.04 and installs eCcodes and'
+  echo 'MPICH3 from source.'
   echo
   echo 'Use the -v argument to automatically install the correct packages, e.g.:'
   echo '  install-um-extras -v 11.2'

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -156,6 +156,7 @@ elif [ $ubuntu_major -eq 22 ]; then
     curl -L -s -S https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.30.2-Source.tar.gz | tar -xz
     cd eccodes-2.30.2-Source
     mkdir -p build && cd build
+    # can't put directly into /usr
     mkdir -p /usr/src/eccodes
     cmake -DCMAKE_INSTALL_PREFIX=/usr/src/eccodes -DENABLE_JPG=ON ../.
     make

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -18,6 +18,7 @@ function usage {
   echo "The packages required for the UM's GRIB functionality vary by UM version:"
   echo ' - UM 11.1 or earlier requires the GRIB-API library.'
   echo ' - UM 11.2 or later requires the EcCodes library.'
+  echo ' - UM 13.3 or later requires the use of Ubuntu 22.04 and installs eCcodes from source.'
   echo 'These two libraries are mutually exclusive and cannot be installed together.'
   echo
   echo 'Use the -v argument to automatically install the correct packages, e.g.:'
@@ -108,19 +109,72 @@ if [ $ubuntu_major -lt 18 ]; then
     ereport "The EcCodes library is not available at this Ubuntu release.
 Upgrade to Ubuntu 18.04 or later, or supply -v <x.y> to use UM 11.1 or earlier."
   fi
+
+elif [ $ubuntu_major -eq 18 ]; then
+    # Settings for Ubuntu 18.04
+    
+    set -x
+
+    echo "Installing UM and mule dependencies..."
+    apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity libio-stringy-perl libipc-run-perl libperl-critic-perl $grib_library
+
+    echo
+    echo "Adding mule to the installed python packages..."
+    echo "$HOME/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth
+    
+    echo
+    echo "Installing UMDP dependencies..."
+    apt-get install -y texlive texlive-latex-extra texlive-generic-extra texlive-science
+    echo
+    echo "Finished."
+
+elif [ $ubuntu_major -eq 22 ]; then
+    # Settings for Ubuntu 22.04
+
+    echo "Installing UM and mule dependencies..."
+    apt-get install -y libnetcdf-dev libhdf5-dev netcdf-bin libnetcdff-dev libnetcdff7 $grib_library
+
+    echo
+    echo "Configuring UM python settings..."
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    update-alternatives --install /usr/bin/python python /usr/bin/python2 2
+    pip2 install numpy mock
+    echo
+    echo "Adding mule to the installed python packages..."
+    echo "$HOME/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth
+    
+    echo
+    echo "Installing UMDP dependencies..."
+    apt-get install -y texlive texlive-latex-extra texlive-science
+
+    echo
+    echo "Installing eCcodes from source..."
+    sudo apt-get install libnetcdff-dev libopenjp2-7-dev gfortran make unzip git cmake wget
+    cd
+    wget https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.30.2-Source.tar.gz
+    tar -xzf eccodes-2.30.2-Source.tar.gz
+    cd eccodes-2.30.2-Source
+    mkdir build && cd build
+    mkdir /usr/src/eccodes
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/src/eccodes -DENABLE_JPG=ON ../eccodes-2.30.2-Source
+    make
+    ctest
+    make install
+    cp -r /usr/src/eccodes/bin/* /usr/bin/.
+    cp /usr/src/eccodes/lib/libeccodes.so /usr/lib/.
+    cp /usr/src/eccodes/include/* /usr/include/.
+
+    echo
+    echo "Installing MPICH3 from source..."
+    cd
+    wget https://www.mpich.org/static/downloads/3.4.3/mpich-3.4.3.tar.gz
+    tar -xzf mpich-3.4.3.tar.gz
+    cd mpich-3.4.3
+    ./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-option-checking --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --disable-maintainer-mode --disable-dependency-tracking --with-libfabric=/usr --with-device=ch3 --with-pm=hydra --with-slurm=/usr --with-hwloc-prefix=/usr --with-wrapper-dl-type=none --enable-shared --without-yaksa --prefix=/usr --enable-fortran=all --disable-rpath --disable-wrapper-rpath --sysconfdir=/etc/mpich --libdir=/usr/lib/x86_64-linux-gnu --includedir=/usr/include/x86_64-linux-gnu/mpich --docdir=/usr/share/doc/mpich CPPFLAGS= CFLAGS= CXXFLAGS= "FFLAGS=-O2 -flto=auto -ffat-lto-objects -fstack-protector-strong  -fallow-invalid-boz -fallow-argument-mismatch" "FCFLAGS=-O2 -flto=auto -ffat-lto-objects -fstack-protector-strong  -fallow-invalid-boz -fallow-argument-mismatch" BASH_SHELL=/bin/bash | tee c.txt
+    make 2>&1 | tee m.txt
+    make install 2>&1 | tee mi.txt
+
+    echo
+    echo "Finished."
+    
 fi
-
-set -x
-
-echo "Installing UM and mule dependencies..."
-apt-get install -y mpich libnetcdf-dev libhdf5-serial-dev netcdf-bin libnetcdff-dev libnetcdff6 python-numpy python-dev python-mock zenity libio-stringy-perl libipc-run-perl libperl-critic-perl $grib_library
-
-echo
-echo "Adding mule to the installed python packages..."
-echo "$HOME/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth
-
-echo
-echo "Installing UMDP dependencies..."
-apt-get install -y texlive texlive-latex-extra texlive-generic-extra texlive-science
-echo
-echo "Finished."

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -153,32 +153,26 @@ elif [ $ubuntu_major -eq 22 ]; then
     echo "Installing eCcodes from source..."
     apt-get install -y libopenjp2-7-dev cmake
     cd /home/${SUDO_USER}
-    wget https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.30.2-Source.tar.gz
-    tar -xzf eccodes-2.30.2-Source.tar.gz
+    curl -L -s -S https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.30.2-Source.tar.gz | tar -xz
     cd eccodes-2.30.2-Source
     mkdir -p build && cd build
-    mkdir -p /usr/src/eccodes
-    cmake -DCMAKE_INSTALL_PREFIX=/usr/src/eccodes -DENABLE_JPG=ON ../.
+    cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_JPG=ON ../.
     make
     ctest
     make install
-    cp /usr/src/eccodes/bin/* /usr/bin/.
-    cp /usr/src/eccodes/lib/*.so /usr/lib/.
-    cp /usr/src/eccodes/include/* /usr/include/.
     cd /home/${SUDO_USER}
-    rm -rf eccodes-2.30.2-Source eccodes-2.30.2-Source.tar.gz
+    rm -rf eccodes-2.30.2-Source
 
     echo
     echo "Installing MPICH3 from source..."
     cd /home/${SUDO_USER}
-    wget https://www.mpich.org/static/downloads/3.4.3/mpich-3.4.3.tar.gz
-    tar -xzf mpich-3.4.3.tar.gz
+    curl -L -s -S https://www.mpich.org/static/downloads/3.4.3/mpich-3.4.3.tar.gz | tar -xz
     cd mpich-3.4.3
     ./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-option-checking --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --disable-maintainer-mode --disable-dependency-tracking --with-libfabric=/usr --with-device=ch3 --with-pm=hydra --with-slurm=/usr --with-hwloc-prefix=/usr --with-wrapper-dl-type=none --enable-shared --without-yaksa --prefix=/usr --enable-fortran=all --disable-rpath --disable-wrapper-rpath --sysconfdir=/etc/mpich --libdir=/usr/lib/x86_64-linux-gnu --includedir=/usr/include/x86_64-linux-gnu/mpich --docdir=/usr/share/doc/mpich CPPFLAGS= CFLAGS= CXXFLAGS= "FFLAGS=-O2 -flto=auto -ffat-lto-objects -fstack-protector-strong  -fallow-invalid-boz -fallow-argument-mismatch" "FCFLAGS=-O2 -flto=auto -ffat-lto-objects -fstack-protector-strong  -fallow-invalid-boz -fallow-argument-mismatch" BASH_SHELL=/bin/bash | tee c.txt
     make 2>&1 | tee m.txt
     make install 2>&1 | tee mi.txt
     cd /home/${SUDO_USER}
-    rm -rf mpich-3.4.3 mpich-3.4.3.tar.gz
+    rm -rf mpich-3.4.3
 
     echo
     echo "Finished."

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -162,6 +162,7 @@ elif [ $ubuntu_major -eq 22 ]; then
     make
     ctest
     make install
+    # now copy necessary files into /usr
     cp /usr/src/eccodes/bin/* /usr/bin/.
     cp /usr/src/eccodes/lib/*.so /usr/lib/.
     cp /usr/src/eccodes/include/* /usr/include/.

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -143,7 +143,7 @@ elif [ $ubuntu_major -eq 22 ]; then
     pip2 install numpy mock
     echo
     echo "Adding mule to the installed python packages..."
-    echo "$HOME/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth
+    echo "/home/${SUDO_USER}/umdir/mule/lib" > /usr/lib/python2.7/dist-packages/mule.pth
     
     echo
     echo "Installing UMDP dependencies..."

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -132,7 +132,7 @@ elif [ $ubuntu_major -eq 22 ]; then
     # Settings for Ubuntu 22.04
 
     echo "Installing UM and mule dependencies..."
-    apt-get install -y libnetcdf-dev libhdf5-dev netcdf-bin libnetcdff-dev libnetcdff7 $grib_library
+    apt-get install -y libnetcdf-dev libhdf5-dev netcdf-bin libnetcdff-dev libnetcdff7
 
     echo
     echo "Configuring UM python settings..."

--- a/usr/local/bin/install-um-extras
+++ b/usr/local/bin/install-um-extras
@@ -149,30 +149,34 @@ elif [ $ubuntu_major -eq 22 ]; then
 
     echo
     echo "Installing eCcodes from source..."
-    sudo apt-get install libnetcdff-dev libopenjp2-7-dev gfortran make unzip git cmake wget
-    cd
+    apt-get install -y libopenjp2-7-dev cmake
+    cd /home/${SUDO_USER}
     wget https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.30.2-Source.tar.gz
     tar -xzf eccodes-2.30.2-Source.tar.gz
     cd eccodes-2.30.2-Source
-    mkdir build && cd build
-    mkdir /usr/src/eccodes
-    cmake -DCMAKE_INSTALL_PREFIX=/usr/src/eccodes -DENABLE_JPG=ON ../eccodes-2.30.2-Source
+    mkdir -p build && cd build
+    mkdir -p /usr/src/eccodes
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/src/eccodes -DENABLE_JPG=ON ../.
     make
     ctest
     make install
-    cp -r /usr/src/eccodes/bin/* /usr/bin/.
-    cp /usr/src/eccodes/lib/libeccodes.so /usr/lib/.
+    cp /usr/src/eccodes/bin/* /usr/bin/.
+    cp /usr/src/eccodes/lib/*.so /usr/lib/.
     cp /usr/src/eccodes/include/* /usr/include/.
+    cd /home/${SUDO_USER}
+    rm -rf eccodes-2.30.2-Source eccodes-2.30.2-Source.tar.gz
 
     echo
     echo "Installing MPICH3 from source..."
-    cd
+    cd /home/${SUDO_USER}
     wget https://www.mpich.org/static/downloads/3.4.3/mpich-3.4.3.tar.gz
     tar -xzf mpich-3.4.3.tar.gz
     cd mpich-3.4.3
     ./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-option-checking --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --disable-maintainer-mode --disable-dependency-tracking --with-libfabric=/usr --with-device=ch3 --with-pm=hydra --with-slurm=/usr --with-hwloc-prefix=/usr --with-wrapper-dl-type=none --enable-shared --without-yaksa --prefix=/usr --enable-fortran=all --disable-rpath --disable-wrapper-rpath --sysconfdir=/etc/mpich --libdir=/usr/lib/x86_64-linux-gnu --includedir=/usr/include/x86_64-linux-gnu/mpich --docdir=/usr/share/doc/mpich CPPFLAGS= CFLAGS= CXXFLAGS= "FFLAGS=-O2 -flto=auto -ffat-lto-objects -fstack-protector-strong  -fallow-invalid-boz -fallow-argument-mismatch" "FCFLAGS=-O2 -flto=auto -ffat-lto-objects -fstack-protector-strong  -fallow-invalid-boz -fallow-argument-mismatch" BASH_SHELL=/bin/bash | tee c.txt
     make 2>&1 | tee m.txt
     make install 2>&1 | tee mi.txt
+    cd /home/${SUDO_USER}
+    rm -rf mpich-3.4.3 mpich-3.4.3.tar.gz
 
     echo
     echo "Finished."


### PR DESCRIPTION
With the move to Ubuntu 22.04, this removed the availability of MPICH3 from apt, and the version of eCcodes available does not provide the necessary .mod file. To be able to build GCOM and the UM it is therefore necessary to change the install-um-extras script to cope with the OS change, where both of these packages are installed from source. The move to python3 as default and removal of the python command from the system also necessitates some changes to allow for this, as well as updating the packages installed.

Additionally, with Ubuntu 18.04 going end-of-life at the end of May 2023, some users may wish to continue using 18.04 via Ubuntu Pro to ensure security updates. However, when apply the necessary changes for this, some parts of the system are broken; gpg-agent and the virtualbox guest additions. Help text has been provided in the README to cover workarounds for both of these, and the inclusion of the -fcommon flag when compiling gpg-agent has been added for 18.04 as if this is included and that package held, it prevents issues following an update.

Changes have been tested in 22.04 and 18.04 with full GCOM and UM installs. 