### PR TITLE
added file for Ubuntu 22.04 on AWS, and updated README and X2Go file

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ Note that, if the plugin does update your Guest Additions then you will need to 
 
 ## Amazon AWS
 
-It is possible to run using Vagrant on an Amazon AWS EC2 virtual machine. To do this you will need to install the [`vagrant-aws`](https://github.com/mitchellh/vagrant-aws) plugin. You do not need VirtualBox. You should ensure that you are using a recent version of Vagrant to enable the AWS plugin to work, and you will first need to run the command
+It is possible to run using Vagrant on an Amazon AWS EC2 virtual machine. To do this you will need to install the [`vagrant-aws`](https://github.com/geckoboard/vagrant-aws) plugin via
+```
+vagrant plugin install vagrant-gecko-aws --entry-point vagrant-aws
+```
+You do not need VirtualBox. You should ensure that you are using a recent version of Vagrant to enable the AWS plugin to work, and you will first need to run the command
 ```
 vagrant box add dummy https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
 ```
@@ -231,7 +235,7 @@ On the [AWS console](https://aws.amazon.com/) you should change your region to t
 
 From here you should click the **All services** drop-down menu, and then click **EC2** to enter the EC2 Dashboard.
 
-There are many different types of EC2 VMs (e.g. Ubuntu, Amazon Linux etc.), which are identified by their unique **ami-** identifier. This identifier is also unique to a particular region. The setting for Ubuntu 18.04 LTS in the London (eu-west-2) region has already been set in the `aws.ami` setting in the provided Vagrantfile. If you wish to use a different region you will need to search for the correct _ami-_ identifier from the **Launch instance** option within the EC2 Dashboard and then set this in the Vagrantfile accordingly.
+There are many different types of EC2 VMs (e.g. Ubuntu, Amazon Linux etc.), which are identified by their unique **ami-** identifier. This identifier is also unique to a particular region. The setting for Ubuntu 18.04 LTS or Ubuntu 22.04 LTS in the London (eu-west-2) region has already been set in the `aws.ami` setting in the provided Vagrantfiles, but you may need to first subscribe to use these images. If you wish to use a different region you will need to search for the correct _ami-_ identifier from the **Launch instance** option within the EC2 Dashboard and then set this in the Vagrantfile accordingly.
 
 ### Create your key pair
 

--- a/Vagrantfile.aws_ubuntu-2204
+++ b/Vagrantfile.aws_ubuntu-2204
@@ -1,0 +1,70 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# workaround to deal with "undefined method `except' for #<Hash:...> (NoMethodError)"
+# see https://github.com/mitchellh/vagrant-aws/issues/566
+class Hash
+  def slice(*keep_keys)
+    h = {}
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
+    h
+  end unless Hash.method_defined?(:slice)
+  def except(*less_keys)
+    slice(*keys - less_keys)
+  end unless Hash.method_defined?(:except)
+end
+
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # when provisioning symlink home/ directory to /home/vagrant
+  config.vm.provision :shell, inline: "ln -s /home/$(logname) /home/vagrant"
+
+  # Remove "desktop" from the args below if only accessing via SSH
+  # Remove "mosrs" from the args below if not accessing the Met Office Science Repository Service
+  config.vm.provision :shell, path: "install.sh", args: "ubuntu 2204 desktop mosrs x2go"
+  config.ssh.forward_x11 = true
+
+  # workaround to prevent use of SMB shared folders
+  # see https://github.com/mitchellh/vagrant-aws/issues/365
+  config.vm.allowed_synced_folder_types = [:rsync]
+
+  # AWS box: must use dummy box - run this command prior to bringing VM up
+  # vagrant box add dummy https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
+  # (do not run in metomi-vms directory)
+  # bring up using: vagrant up --provider=aws
+  # Environment variables defined within aws-credentials file, but can be hard-coded here
+  # (do NOT commit key and secret information back to a public repo)
+  config.vm.provider :aws do |aws, override|
+    # need to set up a user within the AWS console prior to bringing VM up
+    aws.access_key_id = ENV['AWS_KEY'] # user key
+    aws.secret_access_key = ENV['AWS_SECRET'] # user secret
+    aws.keypair_name = ENV['AWS_KEYNAME'] # name of key as named on AWS region (no file ext.)
+    aws.security_groups = "MyIP" # use MyIP - need to set this manually in console
+
+    # Ubuntu-22.04.5 LTS in the London region (eu-west-2)
+    # Subscription is required to launch this instance
+    # OS/VM type determined from AMI - get this from list when searching for instance to launch
+    aws.region = "eu-west-2"
+    aws.ami = "ami-0f4dabdf4d255799d"
+
+    # Name the VM so it can be found in the EC2 instance list
+    aws.tags = {
+      'Name' => "metomi-vms"
+    }
+
+    # VM size
+    # free tier size: 1xCPU/1GB RAM (only 8GB disk as standard)
+    #aws.instance_type = "t2.micro"
+    # larger VM, e.g. Intel Xeon 2xCPU/8GB RAM
+    aws.instance_type = "m5.large"
+    # can change disk size independent of instance type. Free tier up to 30GB.
+    aws.block_device_mapping = [{ 'DeviceName' => '/dev/sda1', 'Ebs.VolumeSize' => 30 }]
+
+    # use dummy box
+    override.vm.box = "dummy"
+    # on AWS EC2 Ubuntu VMs the default username is 'ubuntu' and NOT vagrant
+    override.ssh.username = "ubuntu"
+    override.ssh.private_key_path = ENV['AWS_KEYPATH'] # full path (inc. filename) to key file
+  end
+end

--- a/install-x2go.sh
+++ b/install-x2go.sh
@@ -1,9 +1,7 @@
 #### Install the X2Go for desktop connections - only for Ubuntu currently
 if [[ $dist == ubuntu ]]; then
-  if [[ $release == 1804 ]]; then
-    apt-get install -q -y software-properties-common || error
-    add-apt-repository -y ppa:x2go/stable || error
-    apt-get -q -y update || error
-    apt-get install -q -y x2goserver x2goserver-xsession x2golxdebindings || error
-  fi
+  apt-get install -q -y software-properties-common || error
+  add-apt-repository -y ppa:x2go/stable || error
+  apt-get -q -y update || error
+  apt-get install -q -y x2goserver x2goserver-xsession x2golxdebindings || error
 fi


### PR DESCRIPTION
Added Vagrantfile for using Ubuntu 22.04 LTS on an Amazon EC2 instance using Vagrant. Has been tested using m5.large and m5.4xlarge instances to install and run UM13.6 connecting via X2Go.

The README has been updated as the original vagrant-aws plugin is out of date and no longer supported, so instructions for using a maintained version are now given. the install-x2go.sh script has also been updated, removing the Ubuntu version dependency.