### PR TITLE
Git for vm

### DIFF
--- a/usr/local/bin/install-cylc8
+++ b/usr/local/bin/install-cylc8
@@ -35,11 +35,12 @@ mamba env remove -n "${conda_env}" 2>/dev/null || true
 echo "[INFO] Creating full build using latest versions for Cylc 8 ..."
 mamba create -v -y -n "${conda_env}"
 conda activate "${conda_env}"
-# Include numpy & netcdf for use by rose ana
+# Include numpy, netcdf and setuptools for use by rose ana
 mamba install -v -y --override-channels --channel=conda-forge \
   jupyterlab \
   "numpy=1" \
   "netCDF4=1" \
+  "setuptools=82.0.0" \
   cylc-flow \
   cylc-uiserver-base \
   cylc-rose \

--- a/usr/local/bin/install-rose-meta
+++ b/usr/local/bin/install-rose-meta
@@ -2,50 +2,24 @@
 set -u
 
 meta_path=/home/vagrant/etc/rose-meta
+clone_path=$meta_path/.git_clones
 meta_file=$meta_path/rose-meta.conf
-
 mkdir -p $meta_path
+mkdir -p $clone_path
 cd $meta_path
+
 if [[ ! -r $meta_file ]]; then
     cat >> $meta_file <<EOF
 ANCIL=https://code.metoffice.gov.uk/svn/ancil/main/trunk/rose-meta
-JULES=https://code.metoffice.gov.uk/svn/jules/main/trunk/rose-meta
-LFRIC-A=https://metomi/svn/lfric.xm/LFRic/trunk/applications/io_demo/rose-meta
-LFRIC-B=https://metomi/svn/lfric.xm/LFRic/trunk/applications/simple_diffusion/rose-meta
-LFRIC-C=https://metomi/svn/lfric.xm/LFRic/trunk/applications/skeleton/rose-meta
-LFRIC-D=https://metomi/svn/lfric.xm/LFRic/trunk/components/coupling/rose-meta
-LFRIC-E=https://metomi/svn/lfric.xm/LFRic/trunk/components/driver/rose-meta
-LFRIC-F=https://metomi/svn/lfric.xm/LFRic/trunk/components/inventory/rose-meta
-LFRIC-G=https://metomi/svn/lfric.xm/LFRic/trunk/components/lfric-xios/rose-meta
-LFRIC-H=https://metomi/svn/lfric.xm/LFRic/trunk/components/science/rose-meta
-LFRIC-I=https://metomi/svn/lfric.xm/LFRic/trunk/mesh_tools/rose-meta
-LFRIC-J=https://metomi/svn/lfric_apps.xm/main/trunk/applications/adjoint_tests/rose-meta
-LFRIC-K=https://metomi/svn/lfric_apps.xm/main/trunk/applications/gravity_wave/rose-meta
-LFRIC-L=https://metomi/svn/lfric_apps.xm/main/trunk/applications/gungho_model/rose-meta
-LFRIC-M=https://metomi/svn/lfric_apps.xm/main/trunk/applications/jedi_lfric_tests/rose-meta
-LFRIC-N=https://metomi/svn/lfric_apps.xm/main/trunk/applications/jules/rose-meta
-LFRIC-O=https://metomi/svn/lfric_apps.xm/main/trunk/applications/lfric2lfric/rose-meta
-LFRIC-P=https://metomi/svn/lfric_apps.xm/main/trunk/applications/lfric_atm/rose-meta
-LFRIC-Q=https://metomi/svn/lfric_apps.xm/main/trunk/applications/lfric_coupled/rose-meta
-LFRIC-R=https://metomi/svn/lfric_apps.xm/main/trunk/applications/linear_model/rose-meta
-LFRIC-S=https://metomi/svn/lfric_apps.xm/main/trunk/applications/ngarch/rose-meta
-LFRIC-T=https://metomi/svn/lfric_apps.xm/main/trunk/applications/shallow_water/rose-meta
-LFRIC-U=https://metomi/svn/lfric_apps.xm/main/trunk/applications/solver/rose-meta
-LFRIC-V=https://metomi/svn/lfric_apps.xm/main/trunk/applications/transport/rose-meta
-LFRIC-W=https://metomi/svn/lfric_apps.xm/main/trunk/interfaces/jules_interface/rose-meta
-LFRIC-X=https://metomi/svn/lfric_apps.xm/main/trunk/interfaces/coupled_interface/rose-meta
-LFRIC-Y=https://metomi/svn/lfric_apps.xm/main/trunk/interfaces/jedi_lfric_interface/rose-meta
-LFRIC-Z=https://metomi/svn/lfric_apps.xm/main/trunk/interfaces/physics_schemes_interface/rose-meta
-LFRIC-1=https://metomi/svn/lfric_apps.xm/main/trunk/interfaces/socrates_interface/rose-meta
-LFRIC-2=https://metomi/svn/lfric_apps.xm/main/trunk/science/adjoint/rose-meta
-LFRIC-3=https://metomi/svn/lfric_apps.xm/main/trunk/science/gungho/rose-meta
-LFRIC-4=https://metomi/svn/lfric_apps.xm/main/trunk/science/linear/rose-meta
-MOCI=https://code.metoffice.gov.uk/svn/moci/main/trunk/rose-meta
 OPS=https://code.metoffice.gov.uk/svn/ops/main/trunk/rose-meta
 ROSES-U=https://code.metoffice.gov.uk/svn/roses-u/R/O/S/I/E/trunk/rose-meta
-UM=https://code.metoffice.gov.uk/svn/um/meta/trunk
 VAR=https://code.metoffice.gov.uk/svn/var/main/trunk/rose-meta
 VER=https://code.metoffice.gov.uk/svn/ver/main/trunk/rose-meta
+LFRIC_APPS=git@github.com:MetOffice/lfric_apps.git
+LFRIC_CORE=git@github.com:MetOffice/lfric_core.git
+JULES=git@github.com:MetOffice/jules.git
+UM=git@github.com:MetOffice/um.git
+MOCI=git@github.com:MetOffice/moci.git
 EOF
     echo [info] Setup $meta_file as follows:
     cat $meta_file
@@ -65,25 +39,67 @@ NAMES=
 for PROJECT in $(rose config -f $meta_file -k); do
     echo [info] Installing / updating metadata for $PROJECT ...
     URL=$(rose config -f $meta_file $PROJECT)
-    svn info --non-interactive $URL >/dev/null 2>&1
-    if [[ $? != 0 ]]; then
-        echo "[WARN] Unable to access $URL, skipping $PROJECT ..."
-    else
-        for NAME in $(svn ls --non-interactive $URL | sed 's#/$##'); do
-            NAMES="${NAMES}${NAME}\n"
-            if [[ -d "${NAME}" ]]; then
-                OLD_URL=$(svn info "${NAME}" | awk -F': ' '$1 == "URL" {print $2}')
-                if [[ "${OLD_URL}" != "${URL}/${NAME}" ]]; then
-                    rm -rf "${NAME}"
-                    echo "  ${NAME}: deleted (URL changed)"
+    if [[ "$URL" == *"code.metoffice.gov.uk"* ]]; then
+        svn info --non-interactive $URL >/dev/null 2>&1
+        if [[ $? != 0 ]]; then
+            echo "[WARN] Unable to access $URL, skipping $PROJECT ..."
+        else
+            for NAME in $(svn ls --non-interactive $URL | sed 's#/$##'); do
+                NAMES="${NAMES}${NAME}\n"
+                if [[ -d "${NAME}" ]]; then
+                    OLD_URL=$(svn info "${NAME}" | awk -F': ' '$1 == "URL" {print $2}')
+                    if [[ "${OLD_URL}" != "${URL}/${NAME}" ]]; then
+                        rm -rf "${NAME}"
+                        echo "  ${NAME}: deleted (URL changed)"
+                    fi
                 fi
+                if [[ -d "${NAME}" ]]; then
+                    echo "  $NAME: updated"
+                    svn update --non-interactive -q "$NAME"
+                else
+                    echo "  $NAME: created"
+                    svn checkout --non-interactive -q "$URL/$NAME"
+                fi
+            done
+        fi
+    else
+        GIT_CLONE=$clone_path/$PROJECT
+        if [[ -d "${GIT_CLONE}" ]]; then
+            git -C ${GIT_CLONE} pull -q
+            if [[ $? != 0 ]]; then
+                echo "[WARN] Unable to access $URL, skipping $PROJECT"
             fi
-            if [[ -d "${NAME}" ]]; then
-                echo "  $NAME: updated"
-                svn update --non-interactive -q "$NAME"
+            echo "[INFO] ${PWD}/${GIT_CLONE}: updated."
+        else
+            git clone -q --depth=1 --branch=main ${URL} ${GIT_CLONE}
+            if [[ $? != 0 ]]; then
+                echo "[WARN] Unable to access $URL, skipping $PROJECT"
+            fi
+            echo "[INFO] ${PWD}/${GIT_CLONE}: created."
+        fi
+        DIR=rose-meta
+        LIST="$(find ${GIT_CLONE}/${DIR} -mindepth 1 -maxdepth 1 -not -path "*/.git" \( -type l -xtype d -o -type d \) -printf '%f\n')"
+        for NAME in ${LIST}
+        do
+            if grep -q "^${NAME}$" <<<"$(echo -e "${NAMES}")"; then
+                echo "[WARN] ${URL} ${DIR} ${NAME}: already in use." >&2
+                continue
+            fi
+            NAMES="${NAMES}${NAME}\n"
+            if [[ -L "${NAME}" ]]; then
+                if [[ $(readlink ${NAME}) != "${GIT_CLONE}/${DIR}/${NAME}" ]]; then
+                    rm "${NAME}"
+                    echo "[INFO] ${PWD}/${NAME}: deleted (wrong symlink)."
+                fi
+            elif [[ -e "${NAME}" ]]; then
+                rm -f -r "${NAME}"
+                echo "[INFO] ${PWD}/${NAME}: deleted (symlink expected)."
+            fi
+            if [[ -L "${NAME}" ]]; then
+                echo "[INFO] ${PWD}/${NAME}: checked."
             else
-                echo "  $NAME: created"
-                svn checkout --non-interactive -q "$URL/$NAME"
+                ln -s "${GIT_CLONE}/${DIR}/${NAME}" "${NAME}"
+                echo "[INFO] ${PWD}/${NAME}: created."
             fi
         done
     fi

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -78,6 +78,10 @@ function get_source_tree {
 
   if [[ $src = *".git"* ]]; then
     # A git url
+    # Expected format <git_url>@<git_ref>
+    # eg. git@github.com:UserName/RepoName.git@main
+    # will get the main branch of that repository
+    # The git_ref is optional - omitting will default to head of the default branch
 
     # Split the source into url and git ref
     delimiter=".git@"

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -141,7 +141,7 @@ function create_keyword {
 process_args $@
 
 cylc_version=${cylc_version:-'8'}
-gcom_src=${gcom_src:-'fcm:gcom.x/trunk@head'}
+gcom_src=${gcom_src:-'git@github.com:MetOffice/gcom.git'}
 shumlib_src=${shumlib_src:-'git@github.com:MetOffice/shumlib.git'}
 
 echo "Preparing the VM for running the Unified Model"

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -76,7 +76,7 @@ function get_source_tree {
   src=$1
   tmpdir=$2
 
-  if [[ $src = *.git ]]; then
+  if [[ $src = *".git"* ]]; then
     # A git url
 
     # Split the source into url and git ref

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -94,7 +94,7 @@ function get_source_tree {
     ref=${array[1]}
 
     git clone -q $src $tmpdir/wc || { echo "Failed to clone $src"; exit 1; }
-    git -C {$tmpdir/wc} checkout $ref || { echo "Failed to checkout $ref in $tmpdir/wc"; exit 1; }
+    git -C $tmpdir/wc checkout $ref || { echo "Failed to checkout $ref in $tmpdir/wc"; exit 1; }
   elif [[ $src =~ ^fcm:|^svn:|^file:|^http:|^https: ]]; then
     # A URL of some kind
     # Check the location is valid and get the Last Changed Rev

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -149,6 +149,34 @@ echo
 
 ##### .metomi setup #####
 
+echo "Setting up FCM keywords..."
+mkdir -p $HOME/.metomi/fcm
+touch $HOME/.metomi/fcm/keyword.cfg
+
+create_keyword 'um.xm' "https://code.metoffice.gov.uk/svn/um/main"
+create_keyword 'jules.xm' "https://code.metoffice.gov.uk/svn/jules/main"
+create_keyword 'socrates.xm' "https://code.metoffice.gov.uk/svn/socrates/main"
+create_keyword 'casim.xm' "https://code.metoffice.gov.uk/svn/monc/casim"
+create_keyword 'ukca.xm' "https://code.metoffice.gov.uk/svn/ukca/main"
+create_keyword 'um_aux.xm' "https://code.metoffice.gov.uk/svn/um/aux"
+create_keyword 'um_doc.xm' "https://code.metoffice.gov.uk/svn/um/doc"
+create_keyword 'um_meta.xm' "https://code.metoffice.gov.uk/svn/um/meta"
+create_keyword 'mule.xm' "https://code.metoffice.gov.uk/svn/um/mule"
+create_keyword 'moci.xm' "https://code.metoffice.gov.uk/svn/moci/main"
+create_keyword 'shumlib.xm' "https://code.metoffice.gov.uk/svn/utils/shumlib"
+create_keyword 'lfric_apps.xm' "https://code.metoffice.gov.uk/svn/lfric_apps/main"
+create_keyword 'um.offline' "file://$HOME/source/um/offline"
+create_keyword 'jules.offline' "file://$HOME/source/jules/offline"
+create_keyword 'socrates.offline' "file://$HOME/source/socrates/offline"
+create_keyword 'casim.offline' "file://$HOME/source/casim/offline"
+create_keyword 'ukca.offline' "file://$HOME/source/ukca/offline"
+create_keyword 'um_aux.offline' "file://$HOME/source/um_aux/offline"
+create_keyword 'mule.offline' "file://$HOME/source/mule/offline"
+create_keyword 'shumlib.offline' "file://$HOME/source/shumlib/offline"
+
+echo "Local FCM keywords created."
+echo
+
 echo 'Adding rose-ana settings to ~/.metomi/rose.conf for KGO auto-generation...'
 conf_file="$HOME/.metomi/rose.conf"
 

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -76,7 +76,26 @@ function get_source_tree {
   src=$1
   tmpdir=$2
 
-  if [[ $src =~ ^fcm:|^svn:|^file:|^http:|^https: ]]; then
+  if [[ $src = *.git ]]; then
+    # A git url
+
+    # Split the source into url and git ref
+    delimiter=".git@"
+    s=$src$delimiter
+    array=();
+    while [[ $s ]]; do
+      array+=( "${s%%"$delimiter"*}" );
+      s=${s#*"$delimiter"};
+    done;
+    src=${array[0]}
+    if [[ $src != *.git ]]; then
+      src=$src.git
+    fi
+    ref=${array[1]}
+
+    git clone -q $src $tmpdir/wc || { echo "Failed to clone $src"; exit 1; }
+    git -C {$tmpdir/wc} checkout $ref || { echo "Failed to checkout $ref in $tmpdir/wc"; exit 1; }
+  elif [[ $src =~ ^fcm:|^svn:|^file:|^http:|^https: ]]; then
     # A URL of some kind
     # Check the location is valid and get the Last Changed Rev
     rev=$(fcm info $src | awk '/Last Changed Rev/ {print $NF}')
@@ -123,40 +142,13 @@ process_args $@
 
 cylc_version=${cylc_version:-'8'}
 gcom_src=${gcom_src:-'fcm:gcom.x/trunk@head'}
-shumlib_src=${shumlib_src:-'fcm:shumlib.x/trunk@head'}
+shumlib_src=${shumlib_src:-'git@github.com:MetOffice/shumlib.git'}
 
 echo "Preparing the VM for running the Unified Model"
 echo
 
 ##### .metomi setup #####
 
-echo "Setting up FCM keywords..."
-mkdir -p $HOME/.metomi/fcm
-touch $HOME/.metomi/fcm/keyword.cfg
-
-create_keyword 'um.xm' "https://code.metoffice.gov.uk/svn/um/main"
-create_keyword 'jules.xm' "https://code.metoffice.gov.uk/svn/jules/main"
-create_keyword 'socrates.xm' "https://code.metoffice.gov.uk/svn/socrates/main"
-create_keyword 'casim.xm' "https://code.metoffice.gov.uk/svn/monc/casim"
-create_keyword 'ukca.xm' "https://code.metoffice.gov.uk/svn/ukca/main"
-create_keyword 'um_aux.xm' "https://code.metoffice.gov.uk/svn/um/aux"
-create_keyword 'um_doc.xm' "https://code.metoffice.gov.uk/svn/um/doc"
-create_keyword 'um_meta.xm' "https://code.metoffice.gov.uk/svn/um/meta"
-create_keyword 'mule.xm' "https://code.metoffice.gov.uk/svn/um/mule"
-create_keyword 'moci.xm' "https://code.metoffice.gov.uk/svn/moci/main"
-create_keyword 'shumlib.xm' "https://code.metoffice.gov.uk/svn/utils/shumlib"
-create_keyword 'lfric_apps.xm' "https://code.metoffice.gov.uk/svn/lfric_apps/main"
-create_keyword 'um.offline' "file://$HOME/source/um/offline"
-create_keyword 'jules.offline' "file://$HOME/source/jules/offline"
-create_keyword 'socrates.offline' "file://$HOME/source/socrates/offline"
-create_keyword 'casim.offline' "file://$HOME/source/casim/offline"
-create_keyword 'ukca.offline' "file://$HOME/source/ukca/offline"
-create_keyword 'um_aux.offline' "file://$HOME/source/um_aux/offline"
-create_keyword 'mule.offline' "file://$HOME/source/mule/offline"
-create_keyword 'shumlib.offline' "file://$HOME/source/shumlib/offline"
-
-echo "Local FCM keywords created."
-echo
 echo 'Adding rose-ana settings to ~/.metomi/rose.conf for KGO auto-generation...'
 conf_file="$HOME/.metomi/rose.conf"
 
@@ -289,7 +281,7 @@ for shum_omp in true false; do
 
 
   # Remove any previous builds
-  make -f make/${vm_config}.mk clean > /dev/null 2>&1 
+  make -f make/${vm_config}.mk clean > /dev/null 2>&1
 
   # Build the library
   echo

--- a/usr/local/bin/um-setup
+++ b/usr/local/bin/um-setup
@@ -222,19 +222,15 @@ get_source_tree "$gcom_src" "$tmpdir"        # Sets global $vn
 echo "Installing GCOM from: $gcom_src"
 
 cd $tmpdir/wc
+export CYLC_VERSION=8
 echo "Running rose stem to build GCOM..."
-
-# explicitly set Cylc version
-# must set to Cylc 8 at the end of the GCOM install for Shumlib if using Cylc 7 for this,
-# as 8 is now the default version
-if [ "$cylc_version" -eq "7" ]; then
-    export CYLC_VERSION=7
-    rose stem --quiet --group=all --name=gcom_install --new --no-gcontrol -- --no-detach
-    export CYLC_VERSION=8
-elif [ "$cylc_version" -eq "8" ]; then
-    export CYLC_VERSION=8
-    rose stem --quiet --group=all --workflow-name=gcom_install --no-run-name
-    cylc play --quiet --no-detach gcom_install
+if [ -d .git ]; then
+    echo "Launching rose-stem via cylc vip as git"
+    # cylc vip -z g=all --workflow-name=gcom_install --no-run-name
+else
+    echo "Launching with rose stem as fcm"
+    # rose stem --quiet --group=all --workflow-name=gcom_install --no-run-name
+    # cylc play --quiet --no-detach gcom_install
 fi
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Changes required to install UM dependencies (shumlib and gcom) post the UM git migration.
The change is primarily adding the code to parse a github url string and clone from there.
The option to checkout from fcm is left there. I've also left the setup of the fcm offline keywords as this might still be useful until mosrs has been removed? Happy to change that if that's preferred. 

The two sources (gcom and shumlib) use ssh access for now as they are both private repos, so this will require an ssh key being setup first. I'll need to update the UM VM doc paper to note this.